### PR TITLE
Gemfiles changes to execute tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,9 @@ Branch r5: [![Build Status](https://travis-ci.org/Xymist/declarative_authorizati
 cp gemfiles/{RAILS_VERSION}.gemfile Gemfile
 bundle
 
+echo "#{RUBY_VERSION}" > .ruby-version
+e.g echo '2.6.6' > .ruby-version
+
 bundle exec rake test
 ```
 

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 gem 'rdoc'
 gem 'rails-controller-testing'
 gem 'minitest', '5.10.3'
+gem 'sprockets', '< 4.0.0'
 gemspec path: '..'


### PR DESCRIPTION
Change to limit sqlite3 less than 1.4 and sprockets version less than 4.0 so as to not break tests

The test run for this gem branch after changes:

```
bundle exec rake test 

Finished in 1.174838s, 165.9803 runs/s, 347.2819 assertions/s.
195 runs, 408 assertions, 0 failures, 0 errors, 0 skips
```